### PR TITLE
translate tabs to spaces

### DIFF
--- a/simple-grid.scss
+++ b/simple-grid.scss
@@ -124,9 +124,9 @@ $breakpoint-large: 60em; // 960px
 }
 
 .row::after {
-	content: "";
-	display: table;
-	clear: both;
+  content: "";
+  display: table;
+  clear: both;
 }
 
 .col-1,


### PR DESCRIPTION
Do not mix `tabs` with `spaces`. Choose one of them and stick to it
